### PR TITLE
Upgrade to CertLogic v0.9.1-js

### DIFF
--- a/tooling/package.json
+++ b/tooling/package.json
@@ -16,8 +16,7 @@
   "dependencies": {
     "ajv": "^8.6.0",
     "ajv-formats": "^2.1.0",
-    "certlogic-js": "^0.8.0",
-    "certlogic-validation": "^0.8.0",
+    "certlogic-js": "^0.9.1",
     "deep-equal": "^2.0.5",
     "fs-readdir-recursive": "^1.1.0",
     "semver": "^7.3.5"

--- a/tooling/src/validate.ts
+++ b/tooling/src/validate.ts
@@ -1,5 +1,5 @@
 import { version } from "certlogic-js"
-import { dataAccesses, validateFormat } from "certlogic-validation"
+import { dataAccesses, validateFormat } from "certlogic-js/dist/validation"
 import { gt } from "semver"
 
 import { readJson } from "./file-utils"


### PR DESCRIPTION
so validation/dataAccesses doesn't error on the use of extractFromUVCI