### PR TITLE
Update deps of tooling

### DIFF
--- a/tooling/package.json
+++ b/tooling/package.json
@@ -14,21 +14,21 @@
   "author": "Meinte Boersma",
   "license": "Apache-2.0",
   "dependencies": {
-    "ajv": "^8.6.0",
-    "ajv-formats": "^2.1.0",
-    "certlogic-js": "^0.9.1",
+    "ajv": "^8.8.2",
+    "ajv-formats": "^2.1.1",
+    "certlogic-js": "^1.0.4",
     "deep-equal": "^2.0.5",
     "fs-readdir-recursive": "^1.1.0",
     "semver": "^7.3.5"
   },
   "devDependencies": {
-    "@types/chai": "^4.2.18",
+    "@types/chai": "^4.2.22",
     "@types/deep-equal": "^1.0.1",
-    "@types/mocha": "^8.2.2",
-    "@types/node": "^15.14.0",
-    "@types/semver": "^7.3.6",
+    "@types/mocha": "^9.0.0",
+    "@types/node": "^16.11.10",
+    "@types/semver": "^7.3.9",
     "chai": "^4.3.4",
-    "mocha": "^8.4.0",
-    "typescript": "^4.4.4"
+    "mocha": "^9.1.3",
+    "typescript": "^4.5.2"
   }
 }

--- a/tooling/src/validate.ts
+++ b/tooling/src/validate.ts
@@ -1,4 +1,4 @@
-import { version } from "certlogic-js"
+import { specificationVersion } from "certlogic-js"
 import { dateFromString } from "certlogic-js/dist/internals"
 import { dataAccesses, validateFormat } from "certlogic-js/dist/validation"
 import { gt } from "semver"
@@ -37,8 +37,8 @@ const validateMetaData = (rule: Rule) => {
     if (rule.Engine !== "CERTLOGIC") {
         errors.push(`Engine "${rule.Engine}" must be "CERTLOGIC"`)
     }
-    if (gt(rule.EngineVersion, version)) {
-        errors.push(`EngineVersion ${rule.EngineVersion} is newer than the currently supported version ${version}`)
+    if (gt(rule.EngineVersion, specificationVersion)) {
+        errors.push(`EngineVersion ${rule.EngineVersion} is newer than the currently supported version ${specificationVersion}`)
     }
     if (gt("0.7.5", rule.EngineVersion)) {
         errors.push(`EngineVersion ${rule.EngineVersion} must be 0.7.5 or newer`)


### PR DESCRIPTION
Specifically certlogic-js to a version beyond v1.0.0 to be able to differentiate between spec. and impl. version.
This fixes issue #29 